### PR TITLE
HiDPI: set rounding policy to PassThrough

### DIFF
--- a/QtCollider/interface.cpp
+++ b/QtCollider/interface.cpp
@@ -75,6 +75,12 @@ void QtCollider::init() {
         static char* qcArgv[1] = { qcArg0 };
 
         QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+        // In order to scale the UI properly on Windows with display scaling like 125% or 150%
+        // we need to disable scale factor rounding
+        // This is only available in Qt >= 5.14
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+        QGuiApplication::setHighDpiScaleFactorRoundingPolicy(Qt::HighDpiScaleFactorRoundingPolicy::PassThrough);
+#endif // QT_VERSION
 
         QcApplication* qcApp = new QcApplication(qcArgc, qcArgv);
 

--- a/editors/sc-ide/core/main_function.cpp
+++ b/editors/sc-ide/core/main_function.cpp
@@ -34,6 +34,13 @@ using namespace ScIDE;
 
 int main(int argc, char* argv[]) {
     QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+    // In order to scale the UI properly on Windows with display scaling like 125% or 150%
+    // we need to disable scale factor rounding
+    // This is only available in Qt >= 5.14
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+    QGuiApplication::setHighDpiScaleFactorRoundingPolicy(Qt::HighDpiScaleFactorRoundingPolicy::PassThrough);
+#endif // QT_VERSION
+
     QApplication app(argc, argv);
 
     QStringList arguments(QApplication::arguments());


### PR DESCRIPTION
<!-- Please see CONTRIBUTING.md for guidelines. -->

## Purpose and Motivation

This PR adds support for scale factors like 125%, 150% etc.
Tested on Windows. Needs QT 5.14 to work (but has guards so doesn't break earlier versions).

(without this PR, on Windows 125% and 150% results in scale factor `1x`, while 175% and 200% becomes `2x`)

## Types of changes

<!-- Delete lines that don't apply -->

- Bug fix

## To-do list

<!-- Complete an item by checking it: [x]. Add new entries to track your progress -->

- [x] Code is tested on Windows and Linux
  - [ ] needs further testing on macOS
- [x] This PR is ready for review
